### PR TITLE
feat:感情データを次のフラグメントに持っていく

### DIFF
--- a/MichisirubeApplication/app/build.gradle
+++ b/MichisirubeApplication/app/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
+apply plugin: "androidx.navigation.safeargs"
 
 android {
     compileSdkVersion 30

--- a/MichisirubeApplication/app/src/main/java/com/example/michisirubeapplication/ui/naviEmotion/NaviEmotionFragment.kt
+++ b/MichisirubeApplication/app/src/main/java/com/example/michisirubeapplication/ui/naviEmotion/NaviEmotionFragment.kt
@@ -15,19 +15,37 @@ class NaviEmotionFragment : Fragment() {
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         val view = inflater.inflate(R.layout.fragment_navi_emotion,container,false)
 
-        view.btAnger.setOnClickListener{
-            findNavController().navigate(R.id.action_naviEmotion_to_naviTime)
-        }
-        view.btJoy.setOnClickListener{
-            findNavController().navigate(R.id.action_naviEmotion_to_naviTime)
-        }
-        view.btEnjoyment.setOnClickListener{
-            findNavController().navigate(R.id.action_naviEmotion_to_naviTime)
-        }
-        view.btSad.setOnClickListener{
-            findNavController().navigate(R.id.action_naviEmotion_to_naviTime)
-        }
+
         return view
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        view.btJoy.setOnClickListener{//喜び
+            val emotion: Int = 0
+            val action = NaviEmotionFragmentDirections.actionNaviEmotionToNaviTime(emotion)
+            findNavController().navigate(action)
+        }
+
+        view.btAnger.setOnClickListener{//怒
+            val emotion: Int = 1
+            val action = NaviEmotionFragmentDirections.actionNaviEmotionToNaviTime(emotion)
+            findNavController().navigate(action)
+        }
+
+        view.btSad.setOnClickListener{//悲しみ
+            val emotion: Int = 2
+            val action = NaviEmotionFragmentDirections.actionNaviEmotionToNaviTime(emotion)
+            findNavController().navigate(action)
+        }
+
+        view.btEnjoyment.setOnClickListener{//
+            val emotion: Int = 3
+            val action = NaviEmotionFragmentDirections.actionNaviEmotionToNaviTime(emotion)
+            findNavController().navigate(action)
+        }
+
     }
 
 }

--- a/MichisirubeApplication/app/src/main/java/com/example/michisirubeapplication/ui/naviTime/naviTimeFragment.kt
+++ b/MichisirubeApplication/app/src/main/java/com/example/michisirubeapplication/ui/naviTime/naviTimeFragment.kt
@@ -5,17 +5,37 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TimePicker
+import android.widget.Toast
 import androidx.fragment.app.DialogFragment
+import androidx.navigation.fragment.findNavController
+import androidx.navigation.fragment.navArgs
 import com.example.michisirubeapplication.R
+import kotlinx.android.synthetic.main.fragment_navi_time.view.*
 
 
 class naviTimeFragment : DialogFragment() {
+    private val args: naviTimeFragmentArgs by navArgs()
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-
         val timePicker = TimePicker(activity)
         timePicker.setIs24HourView(true)
         return inflater.inflate(R.layout.fragment_navi_time, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        //感情受け継がれているか確認用のトースト
+        Toast.makeText(activity,args.emotion.toString(),Toast.LENGTH_SHORT)
+            .show()
+
+        view.btTimeSelect.setOnClickListener {
+            //感情と時間を次に受け継ぐコード書く
+            //val time = 0//時間ちゃんととってくる
+            //val action = NaviTimeFragmentDirections.actionsNaviTimeToNaviDestination(args.emotion,time)
+            //findNavController().navigate(action)
+        }
+
     }
 
 }

--- a/MichisirubeApplication/app/src/main/res/layout/fragment_navi_emotion.xml
+++ b/MichisirubeApplication/app/src/main/res/layout/fragment_navi_emotion.xml
@@ -1,82 +1,80 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".ui.naviEmotion.NaviEmotionFragment"
-    android:background="#E5E6EF">
+    android:background="#E5E6EF"
+    tools:context=".ui.naviEmotion.NaviEmotionFragment">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent">
+    <TextView
+        android:id="@+id/textView2"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="100dp"
+        android:layout_marginEnd="8dp"
+        android:text="@string/emotion_desc"
+        android:textSize="25dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
-        <TextView
-            android:id="@+id/textView2"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="8dp"
-            android:layout_marginTop="100dp"
-            android:layout_marginEnd="8dp"
-            android:text="@string/emotion_desc"
-            android:textSize="25dp"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHorizontal_bias="0.5"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+    <Button
+        android:id="@+id/btAnger"
+        android:layout_width="90dp"
+        android:layout_height="90dp"
+        android:layout_marginTop="200dp"
+        android:background="@drawable/button_states"
+        android:onClick="@[() -> naviEmotionViewModel.onClick(@id/btAnger)]"
+        android:text="@string/bt_anger"
+        android:textSize="15dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toEndOf="@+id/btJoy"
+        app:layout_constraintTop_toBottomOf="@+id/textView2" />
 
-        <Button
-            android:id="@+id/btAnger"
-            android:layout_width="90dp"
-            android:layout_height="90dp"
-            android:layout_marginTop="200dp"
-            android:background="@drawable/button_states"
-            android:text="@string/bt_anger"
-            android:textSize="15dp"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHorizontal_bias="0.5"
-            app:layout_constraintStart_toEndOf="@+id/btJoy"
-            app:layout_constraintTop_toBottomOf="@+id/textView2" />
+    <Button
+        android:id="@+id/btJoy"
+        android:layout_width="90dp"
+        android:layout_height="90dp"
+        android:layout_marginTop="200dp"
+        android:background="@drawable/button_states"
+        android:onClick="@[() -> naviEmotionViewModel.onClick(@id/btJoy]"
+        android:text="@string/bt_joy"
+        android:textSize="15dp"
+        app:layout_constraintEnd_toStartOf="@+id/btAnger"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/textView2" />
 
-        <Button
-            android:id="@+id/btJoy"
-            android:layout_width="90dp"
-            android:layout_height="90dp"
-            android:layout_marginTop="200dp"
-            android:background="@drawable/button_states"
-            android:text="@string/bt_joy"
-            android:textSize="15dp"
-            app:layout_constraintEnd_toStartOf="@+id/btAnger"
-            app:layout_constraintHorizontal_bias="0.5"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/textView2" />
+    <Button
+        android:id="@+id/btEnjoyment"
+        android:layout_width="90dp"
+        android:layout_height="90dp"
+        android:background="@drawable/button_states"
+        android:text="@string/bt_enjoyment"
+        android:textSize="15dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toEndOf="@+id/btSad"
+        app:layout_constraintTop_toBottomOf="@+id/btAnger" />
 
-        <Button
-            android:id="@+id/btEnjoyment"
-            android:layout_width="90dp"
-            android:layout_height="90dp"
-            android:background="@drawable/button_states"
-            android:text="@string/bt_enjoyment"
-            android:textSize="15dp"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHorizontal_bias="0.5"
-            app:layout_constraintStart_toEndOf="@+id/btSad"
-            app:layout_constraintTop_toBottomOf="@+id/btAnger" />
+    <Button
+        android:id="@+id/btSad"
+        android:layout_width="90dp"
+        android:layout_height="90dp"
+        android:background="@drawable/button_states"
+        android:text="@string/bt_sad"
+        android:textSize="15dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/btEnjoyment"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/btJoy" />
 
-        <Button
-            android:id="@+id/btSad"
-            android:layout_width="90dp"
-            android:layout_height="90dp"
-            android:background="@drawable/button_states"
-            android:text="@string/bt_sad"
-            android:textSize="15dp"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toStartOf="@+id/btEnjoyment"
-            app:layout_constraintHorizontal_bias="0.5"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/btJoy" />
+</androidx.constraintlayout.widget.ConstraintLayout>
 
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
-</FrameLayout>

--- a/MichisirubeApplication/app/src/main/res/layout/fragment_navi_time.xml
+++ b/MichisirubeApplication/app/src/main/res/layout/fragment_navi_time.xml
@@ -20,5 +20,18 @@
         android:background="#E5E6EF"
     />
 
+    <Button
+        android:id="@+id/btTimeSelect"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/bt_select"
+        android:background="#707070"
+        android:textSize="20sp"
+        android:textColor="#ffffff"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/timePicker" />
+
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/MichisirubeApplication/app/src/main/res/navigation/navigation_graph.xml
+++ b/MichisirubeApplication/app/src/main/res/navigation/navigation_graph.xml
@@ -32,16 +32,28 @@
         android:label="fragment_navi_time"
         tools:layout="@layout/fragment_navi_time">
 
+        <argument
+            android:name="emotion"
+            app:argType="integer"/>
+
         <action
             android:id="@+id/action_third_to_first"
             app:destination="@id/naviDestinationFragment" />
-    </fragment>
 
+    </fragment>
 
     <fragment
         android:id="@+id/naviDestinationFragment"
         android:name="com.example.michisirubeapplication.ui.naviDestination.naviDestinationFragment"
         android:label="fragment_navi_destination"
         tools:layout="@layout/fragment_navi_destination">
+
+        <argument
+            android:name="emotion"
+            app:argType="integer"/>
+        <argument
+            android:name="time"
+            app:argType="integer"/>
+
     </fragment>
 </navigation>

--- a/MichisirubeApplication/app/src/main/res/values/strings.xml
+++ b/MichisirubeApplication/app/src/main/res/values/strings.xml
@@ -17,8 +17,11 @@
     <string name="img_bad">Bad</string>
     <string name="good">Good</string>
     <string name="bad">Bad</string>
-    <string name="hello_blank_fragment">Hello blank fragment</string>
+
+    <string name="bt_select">決定</string>
+
     <string name="green_back">background</string>
     <string name="eva_to_home">ホームへ戻る</string>
+
 
 </resources>

--- a/MichisirubeApplication/build.gradle
+++ b/MichisirubeApplication/build.gradle
@@ -8,6 +8,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:4.0.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath "android.arch.navigation:navigation-safe-args-gradle-plugin:1.0.0"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
## 対応するissue
- close #24 

## 概要
- 感情選択から時間選択に行く際に感情のデータを連れて遷移するようにした．(？)

## 技術的変更点・追加点
- navigationのSafeArgsを使った～
- 確認のためにToastを設置した
-
## 使い方
- 感情を選択する
- 喜怒哀楽によって，0~4の番号がToastで下部に表示される
-

## コードレビューチェックリスト
- [ ] 仕様と実装はあっている
- [ ] 無意味なロジックがない
- [ ] メソッド名、変数名などが適切
- [ ] コーディングルールを守れている

## その他

